### PR TITLE
Release 0.0.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.8-SNAPSHOT
+version=0.0.8


### PR DESCRIPTION
This PR contains the release version 0.0.8 and updates gradle.properties to remove the SNAPSHOT suffix.